### PR TITLE
Fix multi-monitor calibration

### DIFF
--- a/config.py
+++ b/config.py
@@ -108,6 +108,7 @@ class AppConfig:
     result_close_method: str = "click"
     debug_mode: bool = False
     always_on_top: bool = True
+    monitor_index: int = 0
 
     def save(self, path=None):
         path = path or DEFAULT_SETTINGS_PATH

--- a/gui/app.py
+++ b/gui/app.py
@@ -15,6 +15,7 @@ from gui.pages.settings import create_settings
 from gui.sidebar import create_sidebar, set_active_page
 from gui.theme import _FONT_PATH, FONT_SIZES, build_global_theme, set_ui_scale
 from main import NTEFishingBot
+from screeninfo import get_monitors
 
 
 def _get_primary_monitor_size() -> tuple[int, int]:
@@ -260,12 +261,12 @@ class FishingGUI:
         """Move the GUI window to the bottom-left corner to avoid overlapping
         the game's ROI regions (button at bottom-right, bar at top-center)."""
         try:
-            scr_w, scr_h = _get_primary_monitor_size()
+            mon = get_monitors()[CFG.monitor_index]
             vp_w = int(960 * self._ui_scale)
             vp_h = int(700 * self._ui_scale)
             margin = int(50 * self._ui_scale)
-            x = margin
-            y = scr_h - vp_h - margin
+            x = mon.x + margin
+            y = mon.y + mon.height - vp_h - margin
             dpg.set_viewport_pos([x, y])
         except Exception:
             pass

--- a/gui/pages/settings.py
+++ b/gui/pages/settings.py
@@ -29,6 +29,7 @@ from gui.theme import (
     _ui_scale as _s,
     build_settings_cat_theme,
 )
+from screeninfo import get_monitors
 
 # ---------------------------------------------------------------------------
 # Category definitions
@@ -344,6 +345,18 @@ def _build_input_settings(
             callback=lambda s, d: _set(CFG, "debug_mode", d),
         )
 
+        monitors = _monitor_labels()
+        default_monitor = min(CFG.monitor_index, len(monitors) - 1)
+
+        dpg.add_combo(
+            label="Monitor",
+            tag="cfg_monitor_index",
+            items=monitors,
+            default_value=monitors[default_monitor],
+            width=300,
+            callback=lambda s, d: _set_monitor(d, monitors),
+        )
+
         dpg.add_spacer(height=12)
         dpg.add_text("Global Hotkeys", color=TEXT_MUTED)
         dpg.add_spacer(height=4)
@@ -532,6 +545,8 @@ def _refresh_values():
     dpg.set_value("cfg_cal_confidence", CFG.calibration.confidence_threshold)
     dpg.set_value("cfg_cal_roi_padding", CFG.calibration.roi_padding)
 
+    dpg.set_value("cfg_monitor_index", CFG.monitor_index)
+
     dpg.set_value("cfg_hotkey_toggle", CFG.hotkeys.toggle)
     dpg.set_value("cfg_hotkey_stop", CFG.hotkeys.stop)
 
@@ -559,6 +574,11 @@ def _set_key(attr: str, val: str, tag: str):
     else:
         dpg.set_value(tag, getattr(CFG.keys, attr))
 
+def _set_monitor(selected: str, monitors: list[str]):
+    try:
+        CFG.monitor_index = monitors.index(selected)
+    except ValueError:
+        CFG.monitor_index = 0
 
 def _set_hotkey(
     attr: str,
@@ -578,3 +598,16 @@ def _result_method_label(value: str) -> str:
         if method == value:
             return label
     return "Click center"
+
+
+def _monitor_labels():
+    labels = []
+
+    for i, m in enumerate(get_monitors()):
+        primary = " (Primary)" if m.is_primary else ""
+
+        labels.append(
+            f"Monitor {i}{primary} - {m.width}x{m.height}"
+        )
+
+    return labels

--- a/main.py
+++ b/main.py
@@ -16,6 +16,8 @@ import time
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Optional
 
+from screeninfo import get_monitors
+
 from config import CFG, AppConfig, DEFAULT_SETTINGS_PATH
 from modules.logic import FishingState, FishingStateMachine, PIDController
 from modules.utils import APP_DIR, bundled_path
@@ -212,10 +214,28 @@ class NTEFishingBot:
             self.request_stop()
             self._log("Bot stop requested.")
 
+    @staticmethod
+    def get_active_monitor():
+        monitors = get_monitors()
+
+        index = max(0, min(CFG.monitor_index, len(monitors) - 1))
+
+        return monitors[index]
+
     def calibrate(self) -> None:
         self._log("[Calibration] Capturing full screen...")
-        scene = self.capture.grab_full_screen()
-        self._screen_w, self._screen_h = self.capture.get_screen_size()
+
+        mon = self.get_active_monitor()
+
+        region = {
+            "left": mon.x,
+            "top": mon.y,
+            "width": mon.width,
+            "height": mon.height,
+        }
+
+        scene = self.capture.grab_bgr(region)
+        self._screen_w, self._screen_h = mon.width, mon.height
         scale = min(self._screen_w / _DEFAULT_SCREEN_W, self._screen_h / _DEFAULT_SCREEN_H)
         self._scaled_min_area = max(50.0 * scale * scale, 1.0)
         pad = self.cfg.calibration.roi_padding

--- a/modules/io_module.py
+++ b/modules/io_module.py
@@ -38,17 +38,6 @@ class CaptureModule:
         raw = self._get_sct().grab(roi)
         return np.ascontiguousarray(np.array(raw)[..., :3])
 
-    def grab_full_screen(self) -> np.ndarray:
-        """Capture the primary monitor for cold-start calibration."""
-        sct = self._get_sct()
-        return self.grab_bgr(sct.monitors[1])
-
-    def get_screen_size(self) -> tuple[int, int]:
-        """Return the primary monitor size as (width, height)."""
-        sct = self._get_sct()
-        m = sct.monitors[1]
-        return m["width"], m["height"]
-
     def close(self) -> None:
         if self._sct is None:
             return

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mss
 pydirectinput
 dearpygui
 keyboard
+screeninfo


### PR DESCRIPTION
Previously, calibration and screen capture always used Monitor 0, which caused incorrect ROI detection when the game was running on another monitor. This causes problems if Monitor 0 Resolution does not match the Monitor the game is running on.

The bot now captures and calibrates against the selected monitor only. The settings page also includes a monitor dropdown showing detected displays and resolutions for easier configuration.

<img width="938" height="644" alt="image" src="https://github.com/user-attachments/assets/5d6baad1-4e96-4e7b-9820-139023cd0edf" />
