### PR TITLE
fix: input registration under elevated games + false-bite debounce + pause/stop hardening

### DIFF
--- a/config.py
+++ b/config.py
@@ -76,6 +76,9 @@ class TimingConfig:
     struggling_poll_interval: float = 0.01
     bait_error_threshold: int = 3
     max_struggle_secs: float = 120.0
+    # Debounce for the WAITING bite trigger: ignore blue in the button ROI until
+    # it has cleared once (residual cast-UI blue), or this many seconds elapse.
+    bite_arm_delay_secs: float = 2.5
 
 
 @dataclass

--- a/gui/app.py
+++ b/gui/app.py
@@ -15,7 +15,7 @@ from gui.pages.settings import create_settings, update_settings_ui
 from gui.sidebar import create_sidebar, set_active_page
 from gui.theme import _FONT_PATH, FONT_SIZES, build_global_theme, set_ui_scale
 from main import NTEFishingBot, log
-from modules.utils import VERSION, bundled_path
+from modules.utils import ELEVATION_WARNING, VERSION, bundled_path, is_elevated
 from screeninfo import get_monitors
 
 
@@ -34,6 +34,8 @@ class FishingGUI:
         self._enable_hidpi()
         self.bridge = BotBridge()
         self.bot = NTEFishingBot(bridge=self.bridge)
+        if not is_elevated():
+            log.warning(ELEVATION_WARNING)
         self.bot_thread: threading.Thread | None = None
         self._bot_lock = threading.Lock()
         self._hotkey_handles: list = []

--- a/gui/bridge.py
+++ b/gui/bridge.py
@@ -2,7 +2,6 @@
 import dataclasses
 import logging
 import queue
-import time
 from typing import Optional, Tuple
 
 from modules.logic import FishingState
@@ -131,8 +130,3 @@ class BridgeHandler(logging.Handler):
             self.bridge.push_log(msg)
         except Exception:
             self.handleError(record)
-
-
-def _fmt_time() -> str:
-    t = time.localtime()
-    return f"{t.tm_hour:02d}:{t.tm_min:02d}:{t.tm_sec:02d}"

--- a/main.py
+++ b/main.py
@@ -27,11 +27,12 @@ try:
     import cv2
     from screeninfo import get_monitors
     from modules.io_module import CaptureModule, InputModule
-    from modules.vision import VisionModule
+    from modules.vision import VisionModule, _ERROR_WHITE_PIXEL_MIN as _ERR_WHITE_BASE
     _TP_LOADED = True
 except ImportError:
     cv2 = CaptureModule = InputModule = VisionModule = None  # type: ignore[assignment]
     get_monitors = None  # type: ignore[assignment]
+    _ERR_WHITE_BASE = 1200  # mirrors modules.vision._ERROR_WHITE_PIXEL_MIN
     _TP_LOADED = False
 
 if TYPE_CHECKING:
@@ -134,8 +135,8 @@ class NTEFishingBot:
         self._is_stopped = True
         self._fps = 0.0
         self._last_time = time.time()
-        self._last_action = "NONE"
         self._consecutive_waiting_timeouts = 0
+        self._reset_humanization_state()
 
         self._log("Bot initialized.")
         self._csv_handle = None
@@ -163,8 +164,8 @@ class NTEFishingBot:
         self._fps = 0.0
         self._session_start = time.time()
         self._last_time = time.time()
-        self._last_action = "NONE"
         self._consecutive_waiting_timeouts = 0
+        self._reset_humanization_state()
 
     def request_stop(self) -> None:
         self._stop_flag = True
@@ -294,9 +295,8 @@ class NTEFishingBot:
         scale_sq = self._current_scale * self._current_scale
         self._scaled_min_area = max(self.cfg.detection_min_area * scale_sq, 1.0)
         self._scaled_blue_pixels = int(max(self.cfg.min_blue_pixels * scale_sq, 1.0))
-        self._scaled_error_white_min = int(max(1200 * scale_sq, 10.0))
+        self._scaled_error_white_min = int(max(_ERR_WHITE_BASE * scale_sq, 10.0))
         
-        pad = self.cfg.calibration.roi_padding
         self._log(
             f"[Calibration] Screen resolution: {self._screen_w}x{self._screen_h}"
         )
@@ -459,11 +459,20 @@ class NTEFishingBot:
             except Exception:
                 log.debug("Failed to push final status during shutdown.", exc_info=True)
 
+    def _reset_humanization_state(self) -> None:
+        """Reset humanized pulse/reaction state so it never leaks across struggles or runs."""
+        self._hum_reaction_end = 0.0
+        self._hum_pulse_end = 0.0
+        self._hum_pulse_state = "IDLE"
+        self._hum_target_action = "NONE"
+        self._last_action = "NONE"
+
     def _enter_struggling(self) -> None:
         """Common setup when transitioning into STRUGGLING from any state."""
         self._bait_error_count = 0
         self._consecutive_waiting_timeouts = 0
         self._bar_detected_in_struggle = False
+        self._reset_humanization_state()
 
         # Humanized hook reaction latency
         if self.cfg.humanization.enabled:
@@ -484,6 +493,23 @@ class NTEFishingBot:
         self._cursor_x_rel = None
         self._target_x_rel = None
         self.sm.transition(FishingState.STRUGGLING)
+
+    def _interruptible_wait(self, timeout: float) -> bool:
+        """Sleep up to *timeout* seconds, waking early on stop or pause.
+
+        Stop wakes instantly via the stop event; pause is polled at <=50ms
+        granularity. Returns True if a stop or pause was observed, so callers
+        that would otherwise advance state can yield back to the main loop.
+        """
+        if timeout <= 0:
+            return self._stop_flag or self._is_paused
+        deadline = time.monotonic() + timeout
+        while not (self._stop_flag or self._is_paused):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            self._stop_event.wait(timeout=min(remaining, 0.05))
+        return True
 
     def _handle_idle(self) -> None:
         self._log("[IDLE] Casting...")
@@ -520,7 +546,9 @@ class NTEFishingBot:
             anim_secs = cfg_jitter(anim_secs, self.cfg.humanization.cast_animation_jitter, minimum=0.8)
         remaining = anim_secs - 0.3
         if remaining > 0:
-            self._stop_event.wait(timeout=remaining)
+            # Wake promptly on pause/stop; the only follow-up is a
+            # side-effect-free transition, so no need to bail here.
+            self._interruptible_wait(remaining)
         if self._stop_flag:
             return
         self.sm.transition(FishingState.WAITING)
@@ -620,13 +648,6 @@ class NTEFishingBot:
 
             if hcfg.enabled:
                 now = time.perf_counter()
-                
-                # Initialize state variables on first run or transition
-                if not hasattr(self, "_hum_reaction_end"):
-                    self._hum_reaction_end = 0.0
-                    self._hum_pulse_end = 0.0
-                    self._hum_pulse_state = "IDLE"
-                    self._hum_target_action = "NONE"
 
                 # PID noise overlay
                 if hcfg.pid_noise_enabled:
@@ -711,9 +732,7 @@ class NTEFishingBot:
                     if hcfg.deadband_tap_enabled and _RNG.random() < hcfg.deadband_tap_chance:
                         tap_dir = self.cfg.keys.right if error > 0 else self.cfg.keys.left
                         tap_dur = _RNG.uniform(hcfg.deadband_tap_duration_min, hcfg.deadband_tap_duration_max)
-                        # We use pulse_hold here safely since deadband taps are tiny and rare, 
-                        # but ideally this should also be non-blocking. Let's just use pulse_hold as it's quick.
-                        # Wait, tap_dur is ~0.02s, which is a tiny block, acceptable in deadband.
+                        # Deadband taps are tiny (~0.02s) and rare; the brief block is acceptable here.
                         self.input.pulse_hold(tap_dir, tap_dur, 0.0, self._stop_event)
                         
                     action = "NONE"
@@ -828,8 +847,9 @@ class NTEFishingBot:
         result_w = self.cfg.timing.result_wait_secs
         if self.cfg.humanization.enabled:
             result_w = cfg_jitter(result_w, self.cfg.humanization.result_wait_jitter, minimum=1.0)
-        self._stop_event.wait(timeout=result_w)
-        if self._stop_flag:
+        # Bail on stop or pause before the side-effecting follow-up
+        # (fish count + dismiss click). On resume _handle_result re-runs.
+        if self._interruptible_wait(result_w):
             return
 
         # Verify the mini-game actually ended before counting a fish.
@@ -950,7 +970,7 @@ def _cmd_config_show(args: argparse.Namespace) -> None:
             else:
                 print(f"Unknown config path: {section}")
                 return
-        print(json.dumps({parts[-1]: obj} if isinstance(obj, (dict, list)) else {parts[-1]: obj}, indent=4, ensure_ascii=False))
+        print(json.dumps({parts[-1]: obj}, indent=4, ensure_ascii=False))
     else:
         print(json.dumps(data, indent=4, ensure_ascii=False))
 

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Optional
 
 from config import CFG, AppConfig, DEFAULT_SETTINGS_PATH, jitter as cfg_jitter, sample_noise, sample_reaction
 from modules.logic import FishingState, FishingStateMachine, PIDController
-from modules.utils import APP_DIR, bundled_path
+from modules.utils import APP_DIR, ELEVATION_WARNING, bundled_path, is_elevated
 
 # Third-party imports — deferred so entrypoints can validate dependencies first.
 try:
@@ -136,6 +136,7 @@ class NTEFishingBot:
         self._fps = 0.0
         self._last_time = time.time()
         self._consecutive_waiting_timeouts = 0
+        self._bite_armed = False
         self._reset_humanization_state()
 
         self._log("Bot initialized.")
@@ -165,6 +166,7 @@ class NTEFishingBot:
         self._session_start = time.time()
         self._last_time = time.time()
         self._consecutive_waiting_timeouts = 0
+        self._bite_armed = False
         self._reset_humanization_state()
 
     def request_stop(self) -> None:
@@ -551,7 +553,25 @@ class NTEFishingBot:
             self._interruptible_wait(remaining)
         if self._stop_flag:
             return
+        # Disarm the bite trigger so residual cast-UI blue at WAITING entry
+        # isn't mistaken for a bite (see _accept_bite).
+        self._bite_armed = False
         self.sm.transition(FishingState.WAITING)
+
+    def _accept_bite(self, blue_present: bool, time_in_waiting: float) -> bool:
+        """Debounce the WAITING bite trigger.
+
+        Residual blue from the cast UI is often still in the button ROI when
+        WAITING begins, which would fire an instant false 'bite'. Arm the
+        trigger only once blue has cleared (rising edge), or after a fallback
+        delay if it never clears, then accept a blue reading as a real bite.
+        """
+        if not blue_present:
+            self._bite_armed = True
+            return False
+        if not self._bite_armed and time_in_waiting >= self.cfg.timing.bite_arm_delay_secs:
+            self._bite_armed = True
+        return self._bite_armed
 
     def _handle_waiting(self) -> None:
         if self.sm.time_in_state > self.cfg.timing.bite_timeout_secs:
@@ -571,11 +591,12 @@ class NTEFishingBot:
             return
 
         btn_img = self.capture.grab_bgr(self._roi_button)
-        if self.vision.check_blue_trigger(
+        blue = self.vision.check_blue_trigger(
             btn_img,
             self.cfg.hsv.blue,
             self._scaled_blue_pixels,
-        ):
+        )
+        if self._accept_bite(blue, self.sm.time_in_state):
             self._log("[WAITING] Fish hooked (blue trigger).")
             self._enter_struggling()
         else:
@@ -1160,6 +1181,9 @@ if __name__ == "__main__":
     from modules.deps import CLI_PACKAGES, exit_if_missing_dependencies
 
     exit_if_missing_dependencies(CLI_PACKAGES)
+
+    if not is_elevated():
+        log.warning(ELEVATION_WARNING)
 
     if not _TP_LOADED:
         import cv2  # noqa: F811

--- a/main.py
+++ b/main.py
@@ -506,12 +506,14 @@ class NTEFishingBot:
         if timeout <= 0:
             return self._stop_flag or self._is_paused
         deadline = time.monotonic() + timeout
-        while not (self._stop_flag or self._is_paused):
+        while True:
+            self._poll_commands()
+            if self._stop_flag or self._is_paused:
+                return True
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 return False
             self._stop_event.wait(timeout=min(remaining, 0.05))
-        return True
 
     def _handle_idle(self) -> None:
         self._log("[IDLE] Casting...")

--- a/modules/io_module.py
+++ b/modules/io_module.py
@@ -66,12 +66,21 @@ class InputModule:
         self._lock = threading.Lock()
 
     def press(self, key: str, duration: float = 0.05) -> None:
-        """Press and release a key without changing the held-key set."""
-        pydirectinput.keyDown(key)
+        """Press and release a key, tracking it as held for the duration.
+
+        Tracking lets a concurrent release_all() (e.g. a stop issued from the
+        GUI thread mid-press) clean the key up. A redundant keyUp from both
+        paths is harmless.
+        """
+        with self._lock:
+            self._held.add(key)
         try:
+            pydirectinput.keyDown(key)
             time.sleep(duration)
         finally:
             pydirectinput.keyUp(key)
+            with self._lock:
+                self._held.discard(key)
 
     def hold(self, key: str) -> None:
         """Keep a key held down."""

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,4 +1,5 @@
 """Shared utilities for NTE Auto-Fish."""
+import ctypes
 import logging
 import os
 import sys
@@ -37,3 +38,27 @@ def get_version() -> str:
 
 
 VERSION = get_version()
+
+# Shown when the bot lacks the admin rights many games require for input.
+ELEVATION_WARNING = (
+    "Not running as administrator. If the game runs elevated (NTE and many "
+    "games do), key inputs (Pull Left/Right) will NOT register even though the "
+    "on-screen tracker works. Re-launch with run.bat / start_gui.bat (these "
+    "auto-elevate) or right-click the launcher and choose 'Run as administrator'."
+)
+
+
+def is_elevated() -> bool:
+    """Return True if the process has administrator privileges.
+
+    Windows blocks synthetic input (SendInput) from a lower integrity level to
+    an elevated window, so a non-elevated bot can see the screen but cannot
+    control an elevated game. Non-Windows platforms report True (not applicable).
+    """
+    if os.name != "nt":
+        return True
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except Exception:
+        log.debug("IsUserAnAdmin check failed; assuming not elevated.", exc_info=True)
+        return False

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,14 @@
 @echo off
+REM Self-elevate: the target game often runs as administrator, and Windows
+REM blocks synthetic key input from a lower integrity level. Without admin the
+REM on-screen tracker works but Pull Left/Right never register.
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process -FilePath '%~f0' -ArgumentList '%*' -Verb RunAs"
+    exit /b
+)
+cd /d "%~dp0"
 where python >nul 2>&1
 if %errorlevel% neq 0 (
     echo Python is not installed or not found in PATH.

--- a/start_gui.bat
+++ b/start_gui.bat
@@ -1,0 +1,19 @@
+@echo off
+REM Launch the GUI elevated. The target game often runs as administrator, and
+REM Windows blocks synthetic key input from a lower integrity level — without
+REM admin the on-screen tracker works but Pull Left/Right never register.
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Requesting administrator privileges...
+    powershell -Command "Start-Process -FilePath '%~f0' -Verb RunAs"
+    exit /b
+)
+cd /d "%~dp0"
+where pythonw >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Python is not installed or not found in PATH.
+    echo Please install Python 3.11+ and check "Add Python to PATH".
+    pause
+    exit /b 1
+)
+start "" pythonw start_gui.py

--- a/tests/logic/test_bite_debounce.py
+++ b/tests/logic/test_bite_debounce.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock
+
+from main import NTEFishingBot
+
+
+class TestBiteDebounce(unittest.TestCase):
+    """The WAITING bite trigger must not fire on residual cast-UI blue.
+
+    Real bites occur seconds after WAITING begins; the cast animation can leave
+    blue in the button ROI at the very start of WAITING, which previously fired
+    an instant false 'bite'. The trigger must arm (blue cleared, or a fallback
+    delay elapsed) before a blue reading counts as a bite.
+    """
+
+    def _make_bot(self) -> NTEFishingBot:
+        bot = NTEFishingBot()
+        bot.input = MagicMock()
+        bot.cfg.timing.bite_arm_delay_secs = 2.0
+        bot._bite_armed = False  # state on fresh WAITING entry
+        return bot
+
+    def test_residual_blue_at_entry_is_ignored(self):
+        bot = self._make_bot()
+        # Blue already present on the first WAITING frame -> not a bite yet.
+        self.assertFalse(bot._accept_bite(blue_present=True, time_in_waiting=0.0))
+        self.assertFalse(bot._accept_bite(blue_present=True, time_in_waiting=0.3))
+
+    def test_arms_after_blue_clears_then_accepts(self):
+        bot = self._make_bot()
+        bot._accept_bite(blue_present=True, time_in_waiting=0.0)   # residual, ignored
+        self.assertFalse(bot._accept_bite(blue_present=False, time_in_waiting=0.5))  # clears -> arm
+        self.assertTrue(bot._accept_bite(blue_present=True, time_in_waiting=3.5))    # real bite
+
+    def test_fallback_delay_arms_when_blue_never_clears(self):
+        bot = self._make_bot()
+        # Blue persists the whole time; must still fire once past the fallback delay.
+        self.assertFalse(bot._accept_bite(blue_present=True, time_in_waiting=1.0))
+        self.assertTrue(bot._accept_bite(blue_present=True, time_in_waiting=2.0))
+
+    def test_clear_reading_alone_does_not_fire(self):
+        bot = self._make_bot()
+        # A no-blue reading arms but never reports a bite on its own.
+        self.assertFalse(bot._accept_bite(blue_present=False, time_in_waiting=5.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/logic/test_humanization.py
+++ b/tests/logic/test_humanization.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import MagicMock
+
+from main import NTEFishingBot
+from modules.logic import FishingState
+
+# Sentinel value that must never survive a reset.
+_STALE = 12345.0
+
+
+class TestHumanizationReset(unittest.TestCase):
+    """The humanized pulse/reaction state must not leak across struggles or runs.
+
+    The GUI reuses a single NTEFishingBot instance across every start, so stale
+    `_hum_*` state from a previous fish/run would corrupt the start of the next
+    struggle (mis-sequenced pulse, skipped reaction delay). Each entry point that
+    begins fresh work must reset it.
+    """
+
+    def _make_bot(self) -> NTEFishingBot:
+        bot = NTEFishingBot()
+        # Avoid real key presses and reaction-latency sleeps in _enter_struggling.
+        bot.input = MagicMock()
+        bot.cfg.humanization.enabled = False
+        return bot
+
+    def _seed_stale_state(self, bot: NTEFishingBot) -> None:
+        bot._hum_reaction_end = _STALE
+        bot._hum_pulse_end = _STALE
+        bot._hum_pulse_state = "HOLD"
+        bot._hum_target_action = "RIGHT"
+        bot._last_action = "RIGHT"
+
+    def _assert_fresh(self, bot: NTEFishingBot) -> None:
+        self.assertEqual(bot._hum_reaction_end, 0.0)
+        self.assertEqual(bot._hum_pulse_end, 0.0)
+        self.assertEqual(bot._hum_pulse_state, "IDLE")
+        self.assertEqual(bot._hum_target_action, "NONE")
+        self.assertEqual(bot._last_action, "NONE")
+
+    def test_init_initializes_humanization_state(self):
+        # Headless `start` never calls prepare_for_run, so __init__ must set these.
+        bot = self._make_bot()
+        self._assert_fresh(bot)
+
+    def test_enter_struggling_clears_stale_state(self):
+        bot = self._make_bot()
+        self._seed_stale_state(bot)
+
+        bot._enter_struggling()
+
+        self.assertIs(bot.sm.state, FishingState.STRUGGLING)
+        self._assert_fresh(bot)
+
+    def test_prepare_for_run_clears_stale_state(self):
+        bot = self._make_bot()
+        self._seed_stale_state(bot)
+
+        bot.prepare_for_run()
+
+        self._assert_fresh(bot)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/logic/test_pause_and_input.py
+++ b/tests/logic/test_pause_and_input.py
@@ -1,0 +1,87 @@
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+from main import NTEFishingBot
+from modules.io_module import InputModule
+
+
+class TestInterruptibleWait(unittest.TestCase):
+    """`_interruptible_wait` must wake promptly on stop or pause."""
+
+    def _make_bot(self) -> NTEFishingBot:
+        bot = NTEFishingBot()
+        bot.input = MagicMock()
+        return bot
+
+    def test_returns_true_immediately_when_paused(self):
+        bot = self._make_bot()
+        bot._is_paused = True
+        start = time.monotonic()
+        self.assertTrue(bot._interruptible_wait(10.0))
+        self.assertLess(time.monotonic() - start, 0.2)
+
+    def test_returns_true_immediately_when_stopped(self):
+        bot = self._make_bot()
+        bot._stop_flag = True
+        bot._stop_event.set()
+        start = time.monotonic()
+        self.assertTrue(bot._interruptible_wait(10.0))
+        self.assertLess(time.monotonic() - start, 0.2)
+
+    def test_returns_false_after_full_timeout(self):
+        bot = self._make_bot()
+        bot._is_paused = False
+        bot._stop_flag = False
+        start = time.monotonic()
+        self.assertFalse(bot._interruptible_wait(0.1))
+        self.assertGreaterEqual(time.monotonic() - start, 0.09)
+
+    def test_zero_timeout_reports_current_state(self):
+        bot = self._make_bot()
+        bot._is_paused = False
+        bot._stop_flag = False
+        self.assertFalse(bot._interruptible_wait(0.0))
+        bot._is_paused = True
+        self.assertTrue(bot._interruptible_wait(0.0))
+
+    def test_pause_set_mid_wait_wakes_within_poll_interval(self):
+        bot = self._make_bot()
+        bot._is_paused = False
+        bot._stop_flag = False
+
+        def pause_soon():
+            time.sleep(0.05)
+            bot._is_paused = True
+
+        import threading
+        threading.Thread(target=pause_soon, daemon=True).start()
+        start = time.monotonic()
+        # Would otherwise block ~5s; must return shortly after pause is set.
+        self.assertTrue(bot._interruptible_wait(5.0))
+        self.assertLess(time.monotonic() - start, 0.5)
+
+
+class TestPressKeyTracking(unittest.TestCase):
+    """press() must track the key as held so a concurrent release_all() frees it."""
+
+    @patch("modules.io_module.pydirectinput")
+    def test_press_tracks_key_during_hold_and_clears_after(self, mock_pdi):
+        inp = InputModule()
+        observed = {}
+
+        def fake_sleep(_secs):
+            # Mid-press the key must be tracked, so a concurrent stop can release it.
+            observed["held_during_press"] = "f" in inp._held
+            inp.release_all()  # simulate a stop from another thread
+
+        with patch("modules.io_module.time.sleep", side_effect=fake_sleep):
+            inp.press("f", 0.05)
+
+        self.assertTrue(observed["held_during_press"])
+        self.assertNotIn("f", inp._held)
+        self.assertTrue(mock_pdi.keyUp.called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import unittest
+
+from modules.utils import ELEVATION_WARNING, is_elevated
+
+
+class TestElevation(unittest.TestCase):
+    def test_is_elevated_returns_bool_without_raising(self):
+        self.assertIsInstance(is_elevated(), bool)
+
+    def test_elevation_warning_is_actionable(self):
+        text = ELEVATION_WARNING.lower()
+        self.assertIn("administrator", text)
+        self.assertIn("register", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Thanks for NTE Auto-Fish — it's a clean, well-structured tool. While running it against an elevated game I hit a couple of real bugs and fixed them, plus folded in some stability hardening from a code review. Offering them back. Each is in its own commit with tests; happy to split, squash, or adjust to your conventions.

## 1. Input dropped under elevated games (detects-but-won't-control)
**Symptom:** the on-screen tracker works perfectly, but Pull Left/Right never reach the game.
**Cause:** Windows blocks synthetic input (`SendInput`) from a non-elevated process to an elevated window. Screen capture isn't integrity-gated, so the bot *sees* but can't *act*. NTE (and many games) run elevated.
**Fix:**
- Add `is_elevated()` + an `ELEVATION_WARNING` surfaced to both the GUI log and the CLI on startup.
- `run.bat` self-elevates via UAC, and a new `start_gui.bat` does the same for the GUI.

## 2. False "Fish hooked!" immediately after casting
**Symptom:** instant false bite right after a cast → hook → never-sees-bar → recast loop.
**Cause:** residual blue from the cast UI is still in the button ROI at `WAITING` entry.
**Fix:** `_accept_bite()` arms only on a rising edge (after the blue clears) or after a fallback `timing.bite_arm_delay_secs` (default 2.5s), reset on each `WAITING` entry.

## 3. Stability hardening (from a code review)
- **Humanization state leaked across struggles/runs** (the GUI reuses one bot instance) → `_reset_humanization_state()` called from `__init__`, `prepare_for_run`, and `_enter_struggling`.
- **Pause responsiveness:** `_interruptible_wait()` wakes the IDLE/RESULT long waits promptly on pause (was up to ~3s).
- **Input safety:** `press()` now tracks held keys so a concurrent `release_all()` can free them.
- Minor cleanups: source the cast-error white-pixel threshold from `vision._ERROR_WHITE_PIXEL_MIN` instead of a duplicate literal; remove dead code.

## Tests
Added unit tests for each fix (bite debounce, elevation helper, humanization reset, interruptible wait, press tracking). Local suite went 19 → 34 passing.